### PR TITLE
Show element IDs in list_symbols output

### DIFF
--- a/src/paradox_script_mcp/tools/symbols.py
+++ b/src/paradox_script_mcp/tools/symbols.py
@@ -62,6 +62,12 @@ def _format_generic(data, raw_data: dict) -> list[str]:
                 lines.append(f"block: {key} ({line_info})" if line_info else f"block: {key}")
         elif isinstance(value_data, list):
             lines.append(f"list: {key} ({len(value_data)} items, {line_info})" if line_info else f"list: {key} ({len(value_data)} items)")
+            for item in value_data:
+                item_data = item._data if hasattr(item, "_data") else item
+                if isinstance(item_data, dict):
+                    item_id = item_data.get("id", "")
+                    if item_id:
+                        lines.append(f"  - {item_id}")
         else:
             # For primitive values, use key_span for single line
             key_pos = data.key_span(key) if hasattr(data, "key_span") else None


### PR DESCRIPTION
## Summary
- `list_symbols`でリスト形式シンボル（`country_event`等）の各要素のIDを表示するように変更
- これにより`get_structure`でアクセスする際のシンボル名を特定可能になる

## 出力例
```
list: country_event (125 items, L1-L5000)
  - AUS_political_events.1
  - AUS_political_events.2
  - AUS_political_events.3
  ...
```

Closes #2