### PR TITLE
Add `search_references`, `find_symbol_at_line`, and `list_files` tools

### DIFF
--- a/src/paradox_script_mcp/server.py
+++ b/src/paradox_script_mcp/server.py
@@ -8,8 +8,9 @@ Provides tools for efficient discovery of HOI4 game scripts.
 from mcp.server.fastmcp import FastMCP
 
 from paradox_script_mcp.core.game import GameContext
-from paradox_script_mcp.tools.explore import list_directories_tool
-from paradox_script_mcp.tools.symbols import list_symbols_tool
+from paradox_script_mcp.tools.explore import list_directories_tool, list_files_tool
+from paradox_script_mcp.tools.search import search_references_tool
+from paradox_script_mcp.tools.symbols import find_symbol_at_line_tool, list_symbols_tool
 from paradox_script_mcp.tools.structure import get_structure_tool
 
 # Global game context instance
@@ -42,6 +43,24 @@ def init_game(game_directory: str) -> str:
 
 
 @mcp.tool()
+def list_files(directory: str) -> str:
+    """
+    List script files (.txt) in a directory.
+
+    Use this to find file names before calling list_symbols or get_structure.
+    Combine with list_directories to navigate the game's script structure.
+
+    Args:
+        directory: Relative path to the directory
+                  (e.g., "common/national_focus", "events")
+
+    Returns:
+        List of .txt file names in the directory.
+    """
+    return list_files_tool(_ctx, directory)
+
+
+@mcp.tool()
 def list_directories() -> str:
     """
     List all known script directories and their purposes.
@@ -53,6 +72,26 @@ def list_directories() -> str:
         List of directories with their purposes in Japanese.
     """
     return list_directories_tool()
+
+
+@mcp.tool()
+def find_symbol_at_line(file_path: str, line: int) -> str:
+    """
+    Find which symbol contains the given line number.
+
+    Use this after search_references returns a file and line number,
+    to identify which symbol (event, focus, achievement, etc.) owns that line.
+    Returns the symbol name and its line range so you can call get_structure next.
+
+    Args:
+        file_path: Relative path to the file
+                  (e.g., "events/MUN_Czechoslovakia.txt")
+        line: Line number to look up (1-based)
+
+    Returns:
+        Symbol name, container type, line range, and a ready-to-use get_structure call.
+    """
+    return find_symbol_at_line_tool(_ctx, file_path, line)
 
 
 @mcp.tool()
@@ -71,6 +110,30 @@ def list_symbols(file_path: str) -> str:
         Compact list of symbols with their types and key attributes.
     """
     return list_symbols_tool(_ctx, file_path)
+
+
+@mcp.tool()
+def search_references(
+    query: str,
+    glob_pattern: str = "**/*.txt",
+    include_lines: bool = False,
+) -> str:
+    """
+    Search for a string across all game script files.
+
+    Use this to find which files reference a flag, event ID, or any other string.
+    By default returns only file paths (token-efficient).
+    Set include_lines=True to also return matching line numbers and content.
+
+    Args:
+        query: String to search for (literal match)
+        glob_pattern: Glob pattern relative to game directory (default: **/*.txt)
+        include_lines: If True, include matching line numbers and content
+
+    Returns:
+        List of files (and optionally lines) containing the query.
+    """
+    return search_references_tool(_ctx, query, glob_pattern, include_lines)
 
 
 @mcp.tool()

--- a/src/paradox_script_mcp/tools/explore.py
+++ b/src/paradox_script_mcp/tools/explore.py
@@ -2,10 +2,40 @@
 Directory exploration tool
 """
 
+from paradox_script_mcp.core.game import GameContext
 from paradox_script_mcp.knowledge.directory_map import (
-    list_directories,
     is_knowledge_loaded,
+    list_directories,
 )
+
+
+def list_files_tool(ctx: GameContext, directory: str) -> str:
+    """
+    List script files in a directory.
+
+    Args:
+        ctx: The game context
+        directory: Relative path to the directory (e.g., "common/national_focus")
+
+    Returns:
+        List of .txt file names in the directory.
+    """
+    if not ctx.is_initialized or ctx.game_directory is None:
+        return "Error: Game not initialized. Call init_game first."
+
+    target = ctx.game_directory / directory
+    if not target.exists():
+        return f"Error: Directory not found: {directory}"
+    if not target.is_dir():
+        return f"Error: Not a directory: {directory}"
+
+    files = sorted(
+        f.name for f in target.iterdir() if f.is_file() and f.suffix == ".txt"
+    )
+    if not files:
+        return f"No .txt files found in {directory}"
+
+    return "\n".join(files)
 
 
 def list_directories_tool() -> str:

--- a/src/paradox_script_mcp/tools/search.py
+++ b/src/paradox_script_mcp/tools/search.py
@@ -1,0 +1,68 @@
+"""
+Cross-file reference search tool
+"""
+
+import re
+
+from paradox_script_mcp.core.game import GameContext
+
+
+def search_references_tool(
+    ctx: GameContext,
+    query: str,
+    glob_pattern: str = "**/*.txt",
+    include_lines: bool = False,
+) -> str:
+    """
+    Search for a string across all game script files.
+
+    Scans files matching glob_pattern for occurrences of query.
+    By default returns only file paths (token-efficient).
+    Set include_lines=True to also return matching line numbers and content.
+
+    Args:
+        ctx: The game context
+        query: String to search for (literal match)
+        glob_pattern: Glob pattern relative to game directory (default: **/*.txt)
+        include_lines: If True, include matching line numbers and content
+
+    Returns:
+        List of files (and optionally lines) containing the query.
+    """
+    if not ctx.is_initialized or ctx.game_directory is None:
+        return "Error: Game not initialized. Call init_game first."
+
+    game_dir = ctx.game_directory
+    results: list[str] = []
+    pattern = re.compile(re.escape(query))
+
+    for path in sorted(game_dir.glob(glob_pattern)):
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8-sig", errors="replace")
+        except OSError:
+            continue
+
+        if query not in text:
+            continue
+
+        rel = path.relative_to(game_dir).as_posix()
+
+        if not include_lines:
+            results.append(rel)
+        else:
+            matches = []
+            for i, line in enumerate(text.splitlines(), start=1):
+                if pattern.search(line):
+                    matches.append(f"  L{i}: {line.strip()}")
+            if matches:
+                results.append(rel)
+                results.extend(matches)
+
+    if not results:
+        return f"No matches found for: {query}"
+
+    file_count = len([r for r in results if not r.startswith("  ")])
+    header = f"Found in {file_count} file(s):"
+    return header + "\n" + "\n".join(results)

--- a/src/paradox_script_mcp/tools/structure.py
+++ b/src/paradox_script_mcp/tools/structure.py
@@ -60,7 +60,7 @@ def get_structure_tool(
         if block is None:
             return f"Key path not found: {symbol}.{key_path}"
         display_name = f"{symbol}.{key_path}"
-        depth = key_path.count(".") + 1 + len(re.findall(r'\[\d+\]', key_path))
+        depth = key_path.count(".") + 1 + len(re.findall(r"\[\d+\]", key_path))
 
     # If depth >= threshold, expand fully
     expand_full = depth >= EXPAND_DEPTH_THRESHOLD
@@ -199,7 +199,7 @@ def _navigate_key_path(block: Any, key_path: str) -> Any | None:
             return None
 
         # key[N] format (e.g., "option[0]")
-        m = re.match(r'^(.+)\[(\d+)\]$', key)
+        m = re.match(r"^(.+)\[(\d+)\]$", key)
         if m:
             dict_key, idx = m.group(1), int(m.group(2))
             if dict_key not in current:

--- a/src/paradox_script_mcp/tools/symbols.py
+++ b/src/paradox_script_mcp/tools/symbols.py
@@ -7,6 +7,109 @@ from paradox_script.parser import parse_save_file
 from paradox_script_mcp.core.game import GameContext
 
 
+def find_symbol_at_line_tool(ctx: GameContext, file_path: str, line: int) -> str:
+    """
+    Find which symbol contains the given line number.
+
+    Searches top-level blocks and list items (e.g. events, focuses).
+    Returns the symbol name/ID and its line range so the caller can
+    use get_structure to inspect it further.
+
+    Args:
+        ctx: The game context
+        file_path: Relative path to the file
+        line: Line number to look up (1-based)
+
+    Returns:
+        Symbol info: name, type, line range, and id if present.
+    """
+    if not ctx.is_initialized:
+        return "Error: Game not initialized. Call init_game first."
+
+    full_path = ctx.resolve_path(file_path)
+    if not full_path:
+        return f"Error: File not found: {file_path}"
+
+    try:
+        data = parse_save_file(str(full_path))
+    except Exception as e:
+        return f"Error parsing {file_path}: {e}"
+
+    raw_data = data._data if hasattr(data, "_data") else data
+    if not isinstance(raw_data, dict):
+        return "Error: Unexpected file structure"
+
+    def get_span(obj: object) -> tuple[int, int, int, int] | None:
+        raw = getattr(obj, "span", None)
+        if raw is None:
+            return None
+        return (int(raw[0]), int(raw[1]), int(raw[2]), int(raw[3]))
+
+    # Search top-level entries and list items within them
+    for key, value in raw_data.items():
+        top_span = get_span(value)
+        value_data = value._data if hasattr(value, "_data") else value
+
+        if isinstance(value_data, list):
+            # e.g. country_event, focus (inside focus_tree), achievement
+            for item in value_data:
+                item_span = get_span(item)
+                if item_span is None or not (item_span[0] <= line <= item_span[2]):
+                    continue
+                item_data = item._data if hasattr(item, "_data") else item
+                item_id = item_data.get("id", "") if isinstance(item_data, dict) else ""
+                name = item_data.get("name", "") if isinstance(item_data, dict) else ""
+                label = item_id or name or "(unnamed)"
+                return (
+                    f"symbol: {label}\n"
+                    f"  container: {key}\n"
+                    f"  lines: L{item_span[0]}-L{item_span[2]}\n"
+                    f'  use: get_structure(file_path, "{label}")'
+                )
+        elif isinstance(value_data, dict):
+            # top-level block (e.g. achievement, focus_tree)
+            if top_span is None or not (top_span[0] <= line <= top_span[2]):
+                continue
+            # Line is inside this top-level block.
+            # First try to find a matching child list item (e.g. focus inside focus_tree)
+            for child_key, child_val in value_data.items():
+                child_data = (
+                    child_val._data if hasattr(child_val, "_data") else child_val
+                )
+                if isinstance(child_data, list):
+                    for item in child_data:
+                        item_span = get_span(item)
+                        if item_span is None or not (
+                            item_span[0] <= line <= item_span[2]
+                        ):
+                            continue
+                        item_data = item._data if hasattr(item, "_data") else item
+                        item_id = (
+                            item_data.get("id", "")
+                            if isinstance(item_data, dict)
+                            else ""
+                        )
+                        label = item_id or "(unnamed)"
+                        return (
+                            f"symbol: {label}\n"
+                            f"  container: {key}.{child_key}\n"
+                            f"  lines: L{item_span[0]}-L{item_span[2]}\n"
+                            f'  use: get_structure(file_path, "{label}")'
+                        )
+            # No child matched — return the top-level block itself
+            block_id = value_data.get("id", "")
+            # Prefer string IDs (event/focus names); numeric IDs (achievement numbers) use key
+            label = block_id if isinstance(block_id, str) and block_id else key
+            return (
+                f"symbol: {label}\n"
+                f"  type: {key}\n"
+                f"  lines: L{top_span[0]}-L{top_span[2]}\n"
+                f'  use: get_structure(file_path, "{label}")'
+            )
+
+    return f"No symbol found containing line {line} in {file_path}"
+
+
 def list_symbols_tool(ctx: GameContext, file_path: str) -> str:
     """
     List symbols in a file (top level only)
@@ -57,11 +160,21 @@ def _format_generic(data, raw_data: dict) -> list[str]:
             # Show block with id if present
             item_id = value_data.get("id", "")
             if item_id:
-                lines.append(f"block: {key} ({line_info}, id={item_id})" if line_info else f"block: {key} (id={item_id})")
+                lines.append(
+                    f"block: {key} ({line_info}, id={item_id})"
+                    if line_info
+                    else f"block: {key} (id={item_id})"
+                )
             else:
-                lines.append(f"block: {key} ({line_info})" if line_info else f"block: {key}")
+                lines.append(
+                    f"block: {key} ({line_info})" if line_info else f"block: {key}"
+                )
         elif isinstance(value_data, list):
-            lines.append(f"list: {key} ({len(value_data)} items, {line_info})" if line_info else f"list: {key} ({len(value_data)} items)")
+            lines.append(
+                f"list: {key} ({len(value_data)} items, {line_info})"
+                if line_info
+                else f"list: {key} ({len(value_data)} items)"
+            )
             for item in value_data:
                 item_data = item._data if hasattr(item, "_data") else item
                 if isinstance(item_data, dict):
@@ -72,6 +185,10 @@ def _format_generic(data, raw_data: dict) -> list[str]:
             # For primitive values, use key_span for single line
             key_pos = data.key_span(key) if hasattr(data, "key_span") else None
             val_line = f"L{key_pos[0]}" if key_pos else ""
-            lines.append(f"value: {key} = {value_data} ({val_line})" if val_line else f"value: {key} = {value_data}")
+            lines.append(
+                f"value: {key} = {value_data} ({val_line})"
+                if val_line
+                else f"value: {key} = {value_data}"
+            )
 
     return lines


### PR DESCRIPTION
- `search_references`: cross-file string search to find where flags/events are referenced
- `find_symbol_at_line`: reverse lookup from line number to owning symbol
- `list_files`: list .txt files in a directory for navigation