### PR TITLE
Add `/generate-knowledge` skill and document game support workflow

### DIFF
--- a/.claude/skills/generate-knowledge/SKILL.md
+++ b/.claude/skills/generate-knowledge/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: generate-knowledge
+description: Generate knowledge YAML for a Paradox game directory. Use this skill when the user wants to create or regenerate `knowledge/{game_type}/directories.yml`, gives a game directory path and asks to scan or analyze it, or wants to add support for a new Paradox game (EU4, CK3, Stellaris, etc.).
+---
+
+# generate-knowledge
+
+Explore a Paradox game directory and generate `knowledge/{game_type}/directories.yml` automatically.
+
+## Usage
+
+```
+/generate-knowledge <game_type> <game_path>
+```
+
+Examples:
+```
+/generate-knowledge hoi4 /path/to/Hearts of Iron IV
+/generate-knowledge eu4 "/path/to/Europa Universalis IV"
+```
+
+## Steps
+
+### 1. Parse arguments
+
+Read `game_type` (e.g. `hoi4`) and `game_path` (absolute path to the game directory) from the user's message. If either is missing, ask for it before proceeding.
+
+### 2. Enumerate directories
+
+List the top-level entries of `game_path`. Then, if a `common/` subdirectory exists, also list its immediate children. Collect all unique directory paths relative to `game_path`.
+
+### 3. Sample each directory
+
+For each candidate directory, check whether it contains `.txt` files (look at direct children only — no need to recurse).
+
+**Skip the directory entirely** if any of these apply:
+- No `.txt` files exist in it
+- The directory name strongly suggests non-script content: `gfx`, `interface`, `music`, `fonts`, `sound`, `icons`, `portraits`, `flags`, `map`, `pdx_browser`
+
+For directories that pass the check:
+- List up to 5 `.txt` file names
+- Read the first ~20 lines of one file to get a sense of the top-level block types and IDs
+
+From the file names and top-level block structure, write a concise English description of the directory's purpose (one line, no trailing period).
+
+### 4. Write the YAML
+
+Output path: `knowledge/{game_type}/directories.yml` relative to this repository root (not inside the game directory).
+
+**Never include the absolute game path anywhere in the YAML.**
+
+Use this template:
+
+```yaml
+# {game_type} Directory Knowledge
+# Auto-generated — review and correct descriptions as needed.
+
+directories:
+  some/path:
+    description: Brief purpose in English
+
+  another/path:
+    description: Brief purpose in English
+```
+
+- Use forward slashes for paths
+- Sort entries alphabetically
+- If an existing file is present, confirm with the user before overwriting
+
+### 5. Report
+
+Tell the user:
+- How many directories were added
+- How many were skipped (non-text) and why (one-line summary)
+- Which entries you're least confident about so the user knows where to double-check

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ htmlcov/
 .DS_Store
 Thumbs.db
 
-.claude/
+.claude/*
+!.claude/skills/

--- a/README.ja.md
+++ b/README.ja.md
@@ -312,7 +312,39 @@ get_structure(
 
 ## 各ゲームへの対応方法
 
-`src/paradox_script_mcp/knowledge/` 以下にディレクトリやファイルの知識をいれたyamlを置くことで対応できます。現在はHoI4の知識のみ備わっています。
+新しいゲームに対応するには、`knowledge/{game_type}/directories.yml` にスクリプトディレクトリの一覧と用途を記述したYAMLを置く必要があります。
+
+### `/generate-knowledge` スキルを使う（Claude Code）
+
+Claude Codeを使っている場合、組み込みの `/generate-knowledge` スキルでゲームディレクトリを自動スキャンしてYAMLを生成できます。
+
+```
+/generate-knowledge <game_type> <game_path>
+```
+
+例：
+
+```
+/generate-knowledge eu4 "/path/to/Europa Universalis IV"
+/generate-knowledge ck3 "/path/to/Crusader Kings III"
+```
+
+スキルはゲームディレクトリ内の各サブディレクトリにある `.txt` ファイルをサンプリングし、`knowledge/{game_type}/directories.yml` に一行の説明付きで書き出します。`gfx`・`interface`・`music` などの非スクリプトディレクトリは自動的にスキップされます。
+
+### 手動で作成する
+
+`knowledge/{game_type}/directories.yml` を手動で作成することもできます：
+
+```yaml
+# {game_type} Directory Knowledge
+
+directories:
+  some/path:
+    description: Brief purpose in English
+
+  another/path:
+    description: Brief purpose in English
+```
 
 ## プロジェクト構成
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,39 @@ get_structure(
 
 ## Adding Support for Other Games
 
-You can add support by placing YAML files with directory and file knowledge under `src/paradox_script_mcp/knowledge/`. Currently, only HoI4 knowledge is included.
+To add support for a new game, you need a `knowledge/{game_type}/directories.yml` file that lists the game's script directories and their purposes.
+
+### Using the `/generate-knowledge` skill (Claude Code)
+
+If you are using Claude Code, the built-in `/generate-knowledge` skill can scan a game directory and generate the YAML automatically.
+
+```
+/generate-knowledge <game_type> <game_path>
+```
+
+Examples:
+
+```
+/generate-knowledge eu4 "/path/to/Europa Universalis IV"
+/generate-knowledge ck3 "/path/to/Crusader Kings III"
+```
+
+The skill scans the game directory, samples `.txt` files in each subdirectory, and writes `knowledge/{game_type}/directories.yml` with a one-line description for each directory. Non-script directories (`gfx`, `interface`, `music`, etc.) are skipped automatically.
+
+### Manual
+
+You can also create the YAML manually at `knowledge/{game_type}/directories.yml`:
+
+```yaml
+# {game_type} Directory Knowledge
+
+directories:
+  some/path:
+    description: Brief purpose in English
+
+  another/path:
+    description: Brief purpose in English
+```
 
 ## Project Structure
 


### PR DESCRIPTION
- Add `.claude/skills/generate-knowledge/SKILL.md`: a Claude Code slash
  command that scans a Paradox game directory, samples .txt files in
  each subdirectory, and writes `knowledge/{game_type}/directories.yml`
  with one-line descriptions. Non-script dirs (gfx, interface, etc.)
  are skipped automatically.
- Track `.claude/skills/` in git by switching `.claude/` → `.claude/*` and
  adding a `!.claude/skills/` negation in .gitignore.
- Expand "Adding Support for Other Games" in README (en/ja) to document
  the skill and the manual YAML format; fix stale `knowledge/` path.